### PR TITLE
Changed wording from 'slave' to 'subordinate'

### DIFF
--- a/cordovadocs/2017/build-deploy/get-started-with-ci.md
+++ b/cordovadocs/2017/build-deploy/get-started-with-ci.md
@@ -91,7 +91,7 @@ To use Gulp with your Cordova projects, follow these steps:
 
 6. **Configure CI:** Configure your Team/CI server to fetch your Cordova project and execute the same commands mentioned above from the root of your Cordova project. You can find detailed instructions for certain CI systems [below](#ci).
 
-7. **Windows & OSX Build Agents:** Finally, configure an build agent / slave on both Windows and OSX so you can build for any platform. See the tutorials below for some specifics on how to configure your CI system.
+7. **Windows & OSX Build Agents:** Finally, configure a build agent / subordinate on both Windows and OSX so you can build for any platform. See the tutorials below for some specifics on how to configure your CI system.
 
 That's it!
 


### PR DESCRIPTION
The change I made edits the word 'slave' to 'subordinate' to be in line with the Style Guide (https://github.com/MicrosoftDocs/microsoft-style-guide/blob/master/styleguide/bias-free-communication.md).