### PR TITLE
Shorten title in app-lifecycle-management.md

### DIFF
--- a/cordovadocs/2017/build-deploy/app-lifecycle-management.md
+++ b/cordovadocs/2017/build-deploy/app-lifecycle-management.md
@@ -1,6 +1,7 @@
 ---
 assetid: B6275B52-4C94-40EA-BBD6-B0CD415F2CA2
 title: "Application Lifecycle Management (ALM) with Apache Cordova Apps"
+titleSuffix: ""
 description: "Visual Studio and Visual Studio Team Services (VSTS) provide a variety of DevOps capabilities (also referred to as application lifecycle management or ALM) for development organizations, a number of which are applicable to Cordova apps. Tools that are designed for .NET languages like C#, however, do not apply to JavaScript code. Other tools require tight integration with build and runtime environments. Because Cordova apps on Windows run as native apps, you’re able to use a variety of Visual Studio’s diagnostic tools such as performance profilers that are not available for non-Windows platforms."
 services: "na"
 author: "kraigb"


### PR DESCRIPTION
add titleSuffix metadata which overrides the default titleSuffix set in docfx.json
This brings the title down to 63 characters, which is under the recommended 70-character limit