### PR TITLE
address sensitive language

### DIFF
--- a/cordovadocs/2015/access-device-capabilities/use-cordova-plugins.md
+++ b/cordovadocs/2015/access-device-capabilities/use-cordova-plugins.md
@@ -227,6 +227,9 @@ Provides access to the device’s Contacts database.
 
 <hr />
 
+<!-- *** 
+cordova-plugin-whitelist is the name of the underlying plugin - might be incorrect to change this term, even though it's sensitive, until the underlying product is updated
+*** -->
 ## Whitelist: Restrict your app's access to external domains
 
 <button class="plugin-button-readme" onclick="window.location='https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-whitelist/index.html';">Readme</button>

--- a/cordovadocs/2015/build-deploy/get-started-with-ci.md
+++ b/cordovadocs/2015/build-deploy/get-started-with-ci.md
@@ -77,7 +77,7 @@ To get going quickly, follow these steps:
 
 6. **Configure CI:** Next, configure your Team / CI server to fetch your project and execute the exact same commands mentioned above from the root of your Cordova project after fetching the source code. You can find detailed instructions for certain CI systems [below](#ci).
 
-7. **Windows & OSX Build Agents:** Finally, configure an build agent / slave on both Windows and OSX so you can build for any platform. See the tutorials below for some specifics on how to configure your CI system.
+7. **Windows & OSX Build Agents:** Finally, configure an build agent on both Windows and OSX so you can build for any platform. See the tutorials below for some specifics on how to configure your CI system.
 
 That's it!
 

--- a/cordovadocs/2015/build-deploy/jenkins.md
+++ b/cordovadocs/2015/build-deploy/jenkins.md
@@ -25,7 +25,7 @@ Since the build process we will describe here is not directly dependent on MSBui
 
 For OSX, the pre-requisites will need to be installed manually, but mirror [the requirements for the Visual Studio remote build agent](https://go.microsoft.com/fwlink/?LinkID=533745). However, unlike with TFS 2013, you do not need to install the remote build agent itself if your OSX machine will only be used for team / CI builds.
 
-For the purposes of this tutorial, we will assume your primary Jenkins build server is installed on Windows. However, it is relatively straight forward to tweak these instructions to have your primary build server be on Linux or OSX. However, be aware that you will need to have a Windows [slave agent](https://go.microsoft.com/fwlink/?LinkID=613696) if you intend to build for the Windows (Windows or Windows Phone 8.1 or Windows 10) or Windows Phone 8 (WP8) Cordova platforms.
+For the purposes of this tutorial, we will assume your primary Jenkins build server is installed on Windows. However, it is relatively straight forward to tweak these instructions to have your primary build server be on Linux or OSX. However, be aware that you will need to have a Windows [agent](https://go.microsoft.com/fwlink/?LinkID=613696) if you intend to build for the Windows (Windows or Windows Phone 8.1 or Windows 10) or Windows Phone 8 (WP8) Cordova platforms.
 
 If you have not already, start out by installing and setting up up Jenkins itself. See the [Jenkins website for details](https://go.microsoft.com/fwlink/?LinkID=613697). Note that you may want to install other [Jenkins plugins](https://go.microsoft.com/fwlink/?LinkID=613704) such as the [Jenkins Git Plugin](https://go.microsoft.com/fwlink/?LinkID=613698) depending on your environment.
 
@@ -59,7 +59,7 @@ We're going to use the [Jenkins NodeJS Plugin](https://go.microsoft.com/fwlink/?
       ![NodeJS Plugin](media/jenkins/jenkins-0-1.png)
 
 ### Additional Setup for iOS Builds
-For iOS, we will be taking advantage of an [Environment Variable Injector plugin](https://go.microsoft.com/fwlink/?LinkID=613700) and a [slave agent](https://go.microsoft.com/fwlink/?LinkID=613696) on OSX. Here's a basic walkthrough for configuring these.  
+For iOS, we will be taking advantage of an [Environment Variable Injector plugin](https://go.microsoft.com/fwlink/?LinkID=613700) and an [agent](https://go.microsoft.com/fwlink/?LinkID=613696) on OSX. Here's a basic walkthrough for configuring these.  
 
 1. Go to the Jenkins Dashboard again (click on "Jenkins" in the upper left hand corner)
 
@@ -76,7 +76,7 @@ For iOS, we will be taking advantage of an [Environment Variable Injector plugin
 
       We will use the EnvInject plugin in our Jenkins project build config for OSX later in this tutorial.
 
-3. Prep OSX for Use with a Slave Agent
+3. Prep OSX for Use with an Agent
 
 	1. First, if you have not already, [install the Java SE JDK](https://go.microsoft.com/fwlink/?LinkID=613705) on your OSX build server as the agent will use it. (The JRE alone is not sufficient.)
 
@@ -90,25 +90,25 @@ For iOS, we will be taking advantage of an [Environment Variable Injector plugin
 
 	![Enable SSH](media/jenkins/jenkins-2.png)
 
-4. Configure an OSX Slave Agent
+4. Configure an OSX Agent
 
-	Next we need to setup our OSX Slave agent. The following is a brief summary. See [here](https://go.microsoft.com/fwlink/?LinkID=613696) for detailed instructions.
+	Next we need to setup our OSX Agent. The following is a brief summary. See [here](https://go.microsoft.com/fwlink/?LinkID=613696) for detailed instructions.
 
    1. Go to the Jenkins Dashboard again
 
    2. Click Manage Jenkins > Manage Nodes > New Node
 
-   3. Select "Dumb Slave" and give it this agent a name
+   3. Select "Permanent Agent" and give it this agent a name
 
-   4. For "Launch Method," choose "Launch slave agents on Unix machines via SSH" and enter the login information based on your Remote Login settings above.
+   4. For "Launch Method," choose "Launch agents on Unix machines via SSH" and enter the login information based on your Remote Login settings above.
 
    5. Add two Labels of "cordova" and "ios". We will use these labels to route builds to the correct server later in this tutorial.
 
    6. Click "Save" when done.
 
-      ![Slave Agent Config](media/jenkins/jenkins-3.png)
+      ![Agent Config](media/jenkins/jenkins-3.png)
 
-      Jenkins will now use SSH to start up the slave agent on OSX as needed.
+      Jenkins will now use SSH to start up the agent on OSX as needed.
 
 5. (Optional) Add Label to Windows Build Node(s)
 
@@ -120,11 +120,11 @@ For iOS, we will be taking advantage of an [Environment Variable Injector plugin
 
    3. Click on the Configure Icon for one of your Windows nodes like "master"
 
-      ![Slave Agent Config](media/jenkins/jenkins-4.png)
+      ![Agent Config](media/jenkins/jenkins-4.png)
 
    4. Enter a label of "cordova" and "windows" and click "Save."
 
-      ![Slave Agent Label Config](media/jenkins/jenkins-5.png)
+      ![Agent Label Config](media/jenkins/jenkins-5.png)
 
 ## Environment Variables
 Next you will need to set the following environment variables if they have not already been configured in your build server environment. These can either be set as system variables on your build server, by checking the "Environment variables" option when [managing your build nodes](https://go.microsoft.com/fwlink/?LinkID=613696), or using the [Environment Variable Injector plugin](https://go.microsoft.com/fwlink/?LinkID=613700) and checking the "Inject environment variables to the build process" option in your project build config.
@@ -236,7 +236,7 @@ Detailed instructions on configuring projects in Jenkins can be found [here](htt
 	~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 #### OSX Project Build Settings
-The OSX version of the build is similar but adds one additional requirement: Unlocking the keychain. For iOS to build, you will need to [configure your signing certificates on the OSX machine](https://go.microsoft.com/fwlink/?LinkID=613702) as you would normally using with user Jenkins uses to start up the slave agent via SSH. Since the agent does not run interactively, you will then need to unlock the keychain for Jenkins to access the signing certificates. Here is a walkthrough of how to make this happen:
+The OSX version of the build is similar but adds one additional requirement: Unlocking the keychain. For iOS to build, you will need to [configure your signing certificates on the OSX machine](https://go.microsoft.com/fwlink/?LinkID=613702) as you would normally using with user Jenkins uses to start up the agent via SSH. Since the agent does not run interactively, you will then need to unlock the keychain for Jenkins to access the signing certificates. Here is a walkthrough of how to make this happen:
 
 1. Go to the Jenkins Dashboard again (click on "Jenkins" in the upper left hand corner)
 
@@ -246,7 +246,7 @@ The OSX version of the build is similar but adds one additional requirement: Unl
 
 	![Build script](media/jenkins/jenkins-9.png)
 
-4. Check "Restrict where this project can be run" and enter a label expression of "**cordova && ios**". This will prevent the build from attempting to run on any Linux slaves you may have configured or OSX machines without Cordova's dependencies installed.
+4. Check "Restrict where this project can be run" and enter a label expression of "**cordova && ios**". This will prevent the build from attempting to run on any Linux agents you may have configured or OSX machines without Cordova's dependencies installed.
 
 5.  Under "Build Environment":
 	1. Check "Inject passwords to the build as environment variables"

--- a/cordovadocs/2017/build-deploy/get-started-with-ci.md
+++ b/cordovadocs/2017/build-deploy/get-started-with-ci.md
@@ -91,7 +91,7 @@ To use Gulp with your Cordova projects, follow these steps:
 
 6. **Configure CI:** Configure your Team/CI server to fetch your Cordova project and execute the same commands mentioned above from the root of your Cordova project. You can find detailed instructions for certain CI systems [below](#ci).
 
-7. **Windows & OSX Build Agents:** Finally, configure an build agent / slave on both Windows and OSX so you can build for any platform. See the tutorials below for some specifics on how to configure your CI system.
+7. **Windows & OSX Build Agents:** Finally, configure an build agent on both Windows and OSX so you can build for any platform. See the tutorials below for some specifics on how to configure your CI system.
 
 That's it!
 

--- a/cordovadocs/2017/build-deploy/jenkins.md
+++ b/cordovadocs/2017/build-deploy/jenkins.md
@@ -34,7 +34,7 @@ Since the build process we will describe here is not directly dependent on MSBui
 
 For macOS, the prerequisites will need to be installed manually, but mirror [the requirements for the Visual Studio remote build agent](https://go.microsoft.com/fwlink/?LinkID=533745). However, unlike with TFS 2013, you do not need to install the remote build agent itself if your macOS system will only be used for team / CI builds.
 
-For the purposes of this tutorial, we will assume your primary Jenkins build server is installed on Windows. However, it is relatively straight forward to tweak these instructions to have your primary build server be on Linux or macOS. However, be aware that you will need to have a Windows [slave agent](https://go.microsoft.com/fwlink/?LinkID=613696) if you intend to build for the Windows (Windows or Windows Phone 8.1 or Windows 10) or Windows Phone 8 (WP8) Cordova platforms.
+For the purposes of this tutorial, we will assume your primary Jenkins build server is installed on Windows. However, it is relatively straight forward to tweak these instructions to have your primary build server be on Linux or macOS. However, be aware that you will need to have a Windows [agent](https://go.microsoft.com/fwlink/?LinkID=613696) if you intend to build for the Windows (Windows or Windows Phone 8.1 or Windows 10) or Windows Phone 8 (WP8) Cordova platforms.
 
 If you have not already, start out by installing and setting up up Jenkins itself. See the [Jenkins website for details](https://go.microsoft.com/fwlink/?LinkID=613697). Note that you may want to install other [Jenkins plugins](https://go.microsoft.com/fwlink/?LinkID=613704) such as the [Jenkins Git Plugin](https://go.microsoft.com/fwlink/?LinkID=613698) depending on your environment.
 
@@ -74,7 +74,7 @@ We're going to use the [Jenkins NodeJS Plugin](https://go.microsoft.com/fwlink/?
 
 ### Additional Setup for iOS Builds
 
-For iOS, we will be taking advantage of an [Environment Variable Injector plugin](https://go.microsoft.com/fwlink/?LinkID=613700) and a [slave agent](https://go.microsoft.com/fwlink/?LinkID=613696) on macOS. Here's a basic walkthrough for configuring these:
+For iOS, we will be taking advantage of an [Environment Variable Injector plugin](https://go.microsoft.com/fwlink/?LinkID=613700) and a [agent](https://go.microsoft.com/fwlink/?LinkID=613696) on macOS. Here's a basic walkthrough for configuring these:
 
 1. Go to the **Jenkins Dashboard** again (click on **Jenkins** in the upper left hand corner),
 
@@ -92,7 +92,7 @@ For iOS, we will be taking advantage of an [Environment Variable Injector plugin
 
       We will use the EnvInject plugin in our Jenkins project build config for macOS later in this tutorial.
 
-3. Prep macOS for Use with a Slave Agent
+3. Prep macOS for Use with an Agent
 
 	1. First, if you have not already done so, [install the Java SE JDK](https://go.microsoft.com/fwlink/?LinkID=613705) on your macOS build server as the agent will use it. (The Java runtime environment [JRE] alone is not sufficient.)
 
@@ -106,25 +106,25 @@ For iOS, we will be taking advantage of an [Environment Variable Injector plugin
 
 	![Enable SSH](media/jenkins/jenkins-04.png)
 
-4. Configure an macOS Slave Agent
+4. Configure an macOS Agent
 
-	Next we need to setup our macOS Slave agent. The following is a brief summary. See [here](https://go.microsoft.com/fwlink/?LinkID=613696) for detailed instructions.
+	Next we need to setup our macOS Agent. The following is a brief summary. See [here](https://go.microsoft.com/fwlink/?LinkID=613696) for detailed instructions.
 
    1. Go to the **Jenkins Dashboard** again
 
    2. Click **Manage Jenkins** > **Manage Nodes** > **New Node**.
 
-   3. Select **Dumb Slave** and give it this agent a **Name**.
+   3. Select **Permanent Agent** and give it this agent a **Name**.
 
-   4. For **Launch Method**, choose **Launch slave agents on Unix machines via SSH**, and then enter the login information based on your Remote Login settings from above.
+   4. For **Launch Method**, choose **Launch agents on Unix machines via SSH**, and then enter the login information based on your Remote Login settings from above.
 
    5. Add two Labels of `cordova` and `ios`. We will use these labels to route builds to the correct server later in this tutorial.
 
    6. Click the **Save** button when done.
 
-      ![Slave Agent Config](media/jenkins/jenkins-05.png)
+      ![Agent Config](media/jenkins/jenkins-05.png)
 
-      Jenkins will now use SSH to start up the slave agent on macOS as needed.
+      Jenkins will now use SSH to start up the agent on macOS as needed.
 
 5. (Optional) Add Labels to Windows Build Node(s)
 
@@ -136,11 +136,11 @@ For iOS, we will be taking advantage of an [Environment Variable Injector plugin
 
    3. Click the **Configure** Icon for one of your Windows nodes like **master**
 
-      ![Slave Agent Config](media/jenkins/jenkins-06.png)
+      ![Agent Config](media/jenkins/jenkins-06.png)
 
    4. Enter a label of `cordova` and `windows` and click **Save**.
 
-      ![Slave Agent Label Config](media/jenkins/jenkins-07.png)
+      ![Agent Label Config](media/jenkins/jenkins-07.png)
 
 ## Environment Variables
 
@@ -245,7 +245,7 @@ Detailed instructions on configuring projects in Jenkins can be found [here](htt
 
 #### macOS Project Build Settings
 
-The macOS version of the build is similar but adds one additional requirement: Unlocking the keychain. For iOS to build, you will need to [configure your signing certificates on the macOS machine](https://go.microsoft.com/fwlink/?LinkID=613702) as you would normally using the user Jenkins uses to start up the slave agent via SSH. Since the agent does not run interactively, you will need to unlock the keychain for Jenkins to access the signing certificates. Here is a walkthrough of how to make this happen:
+The macOS version of the build is similar but adds one additional requirement: Unlocking the keychain. For iOS to build, you will need to [configure your signing certificates on the macOS machine](https://go.microsoft.com/fwlink/?LinkID=613702) as you would normally using the user Jenkins uses to start up the agent via SSH. Since the agent does not run interactively, you will need to unlock the keychain for Jenkins to access the signing certificates. Here is a walkthrough of how to make this happen:
 
 1. Go to the **Jenkins Dashboard** again (click on **Jenkins** in the upper left hand corner).
 
@@ -255,7 +255,7 @@ The macOS version of the build is similar but adds one additional requirement: U
 
 	![Build script](media/jenkins/jenkins-11.png)
 
-4. Check **Restrict where this project can be run** and enter a label expression of `cordova && ios`. This will prevent the build from attempting to run on any Linux slaves you may have configured or macOS machines without the necessary Cordova dependencies installed.
+4. Check **Restrict where this project can be run** and enter a label expression of `cordova && ios`. This will prevent the build from attempting to run on any Linux agents you may have configured or macOS machines without the necessary Cordova dependencies installed.
 
 5.  Under **Build Environment**:
 


### PR DESCRIPTION
- [x] removed term 'slave' - the underlying Jenkins product has also removed the term.

- [ ] could **not** remove the term 'whitelist' the underlying Cordova product still uses it. See [Cordova whitelist plugin](https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-whitelist/index.html) docs. Not sure how to address this.