### PR TITLE
[BULK UPDATE] DocuTune - Rebranding links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Visual Studio Tools for Apache Cordova
 
-This repository contains a set of documents and tutorials for the **[Visual Studio Tools for Apache Cordova](https://aka.ms/cordova).** The documentation is hosted at **[Visual Studio Tools for Apache Cordova documentation](https://docs.microsoft.com/visualstudio/cross-platform/tools-for-cordova/?view=toolsforcordova-2017)**, and any content changes in the current repository will be updated there as well.
+This repository contains a set of documents and tutorials for the **[Visual Studio Tools for Apache Cordova](https://aka.ms/cordova).** The documentation is hosted at **[Visual Studio Tools for Apache Cordova documentation](https://learn.microsoft.com/visualstudio/cross-platform/tools-for-cordova/?view=toolsforcordova-2017)**, and any content changes in the current repository will be updated there as well.
 
 ## We aren't in it alone. 
 
 We are but one part of the larger Cordova community, and that commitment to the community comes through the products we build and the documentation we upkeep. 
 
-Try building your [first cross-platform mobile app](https://docs.microsoft.com/visualstudio/cross-platform/tools-for-cordova/first-steps/build-your-first-app?view=toolsforcordova-2017/) in Visual Studio, give back to the next set of new users in [StackOverflow](http://stackoverflow.com/questions/tagged/visual-studio-cordova), or contribute to our documentation here on GitHub and share the Cordova glory! 
+Try building your [first cross-platform mobile app](https://learn.microsoft.com/visualstudio/cross-platform/tools-for-cordova/first-steps/build-your-first-app?view=toolsforcordova-2017/) in Visual Studio, give back to the next set of new users in [StackOverflow](http://stackoverflow.com/questions/tagged/visual-studio-cordova), or contribute to our documentation here on GitHub and share the Cordova glory! 
 
 ## More Information
 * [Download samples from our Cordova Samples repository](https://github.com/Microsoft/cordova-samples)

--- a/cordovadocs/2017/build-deploy/ci-guide.md
+++ b/cordovadocs/2017/build-deploy/ci-guide.md
@@ -64,7 +64,7 @@ When you execute these commands, the Cordova CLI adds entries to the `config.xml
     <description>
         A simple weather application
     </description>
-    <author email="vscordovatools@microsoft.com" href="https://https://docs.microsoft.com/visualstudio/cross-platform/tools-for-cordova/?view=toolsforcordova-2017">Visual Studio JS Mobile Tooling</author>
+    <author email="vscordovatools@microsoft.com" href="https://https://learn.microsoft.com/visualstudio/cross-platform/tools-for-cordova/?view=toolsforcordova-2017">Visual Studio JS Mobile Tooling</author>
     <content src="index.html" />
     <access origin="*" />
     <allow-intent href="http://*/*" />

--- a/cordovadocs/2017/first-steps/develop-with-typescript.md
+++ b/cordovadocs/2017/first-steps/develop-with-typescript.md
@@ -75,7 +75,7 @@ import * as Application from './application';
 declare var require: (modules: string[], ready: Function, errback: Function) => void;
 
 // Try and load platform-specific code from the /merges folder.
-// More info at https://docs.microsoft.com/visualstudio/cross-platform/tools-for-cordova/take-further/add-platform-specific-content?view=toolsforcordova-2017#Content.
+// More info at https://learn.microsoft.com/visualstudio/cross-platform/tools-for-cordova/take-further/add-platform-specific-content?view=toolsforcordova-2017#Content.
 require(["./platformOverrides"],
     () => Application.initialize(),
     () => Application.initialize());


### PR DESCRIPTION
**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

**DO NOT MERGE THIS PULL REQUEST WHILE IN DRAFT STATUS!** Some of the changes to links and other content are not valid until after go-live.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
